### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,27 +12,27 @@ winbondFlashSPI	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-read	      KEYWORD2
-writePage	  KEYWORD2
-eraseSector	  KEYWORD2
-erase32kBlock KEYWORD2
-erase64kBlock KEYWORD2
-eraseAll	  KEYWORD2
-eraseSuspend  KEYWORD2
-eraseResume   KEYWORD2
-busy		  KEYWORD2
-readManufacturer  KEYWORD2
-readPartID  	  KEYWORD2
-readUniqueID  	  KEYWORD2
-readSR			  KEYWORD2
-begin		KEYWORD2
-end  		KEYWORD2
-bytes		KEYWORD2
-pages		KEYWORD2
-sectors		KEYWORD2
-blocks		KEYWORD2
-setWriteEnable KEYWORD2
-WE 			   KEYWORD2
+read	KEYWORD2
+writePage	KEYWORD2
+eraseSector	KEYWORD2
+erase32kBlock	KEYWORD2
+erase64kBlock	KEYWORD2
+eraseAll	KEYWORD2
+eraseSuspend	KEYWORD2
+eraseResume	KEYWORD2
+busy	KEYWORD2
+readManufacturer	KEYWORD2
+readPartID	KEYWORD2
+readUniqueID	KEYWORD2
+readSR	KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+bytes	KEYWORD2
+pages	KEYWORD2
+sectors	KEYWORD2
+blocks	KEYWORD2
+setWriteEnable	KEYWORD2
+WE	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -42,10 +42,10 @@ WE 			   KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-_W25Q80		LITERAL1
-_W25Q16		LITERAL1
-_W25Q32		LITERAL1
-_W25Q64		LITERAL1
+_W25Q80	LITERAL1
+_W25Q16	LITERAL1
+_W25Q32	LITERAL1
+_W25Q64	LITERAL1
 _W25Q128	LITERAL1
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords